### PR TITLE
Pin Vale version

### DIFF
--- a/.github/workflows/asciidoctor_pull_request.yaml
+++ b/.github/workflows/asciidoctor_pull_request.yaml
@@ -50,6 +50,7 @@ jobs:
       - name: Spell check
         uses: errata-ai/vale-action@v2.0.1
         with:
+          version: 2.30.0
           fail_on_error: ${{ inputs.fail_on_error }}
           files: ${{ inputs.document }}/content
           vale_flags: ${{ inputs.vale_flags }}


### PR DESCRIPTION
Similar update as https://github.com/stakater/.github/pull/89:
> The Vale GitHub action has until now not been pinned to a particular version, so the latest version has always inadvertently been used. Vale had a major version update 10 h ago that broke all current pipelines. Pin the version to the last minor version, so we can do a controlled upgrade to the latest version.