### PR TITLE
Install Asciidoctor as part of Vale spell checking for adoc files

### DIFF
--- a/.github/workflows/asciidoctor_pull_request.yaml
+++ b/.github/workflows/asciidoctor_pull_request.yaml
@@ -47,6 +47,8 @@ jobs:
           wget https://github.com/errata-ai/vale/releases/download/v3.0.5/vale_3.0.5_Linux_64-bit.tar.gz -O vale.tar.gz
           tar -xvzf vale.tar.gz vale
           rm vale.tar.gz
+      - name: Install Asciidoctor
+        run: sudo apt-get install -y asciidoctor
       - name: Spell check
         run: |
           if [ "${{ inputs.vale_config }}" == ".vale.ini" ]; then


### PR DESCRIPTION
Otherwise run fails with `asciidoctor not found`