### PR TITLE
STAKATER_AB_REPOS update

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -19,6 +19,6 @@ jobs:
       - name: Push Latest Tag
         uses: anothrNick/github-tag-action@1.67.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.STAKATER_AB_REPOS }}
           WITH_V: true
           DEFAULT_BUMP: patch


### PR DESCRIPTION
`GITHUB_TOKEN` can't trigger workflows. You need to push the tags using a PAT if you want workflows to run. `STAKATER_AB_REPOS` did not have permissions to run workflows but has been updated now to include that permission.