### PR TITLE
Revert github tag action

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0 # otherwise you will fail to push refs to dest repo
 
       - name: Push Latest Tag
-        uses: anothrNick/github-tag-action@1.67.0
+        uses: anothrNick/github-tag-action@1.61.0
         env:
           GITHUB_TOKEN: ${{ secrets.STAKATER_AB_REPOS }}
           WITH_V: true


### PR DESCRIPTION
Seems like there is some bug in the latest version of `anothrNick/github-tag-action`, although the token has permissions to push tags, the [workflow](https://github.com/stakater-ab/.github/actions/runs/7613865161/job/20734802351) fails with:
```txt
2024-01-22T15:58:30Z: **pushing tag v0.0.2 to repo stakater-ab/.github
  "message": "Bad credentials",
  "documentation_url": "https://docs.github.com/rest"
}
```

https://github.com/stakater-ab/handbook/blob/main/.github/workflows/push.yaml runs successfully in the private handbook repo, and the corresponding template https://github.com/stakater/.github/blob/v0.0.64/.github/workflows/push_container.yaml uses `anothrNick/github-tag-action@1.61.0`, so reverting and trying that.