### PR TITLE
PDF font embedding issue

### DIFF
--- a/.github/workflows/asciidoctor_pull_request.yaml
+++ b/.github/workflows/asciidoctor_pull_request.yaml
@@ -81,14 +81,14 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
-      #- name: Setup Docker on MacOS Runner
-      #  run: |
-      #    brew install docker
-      #    colima start
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+      - name: Setup Docker on MacOS Runner
+        run: |
+          brew install docker
+          colima start
+      #- name: Set up QEMU
+      #  uses: docker/setup-qemu-action@v2
+      #- name: Set up Docker Buildx
+      #  uses: docker/setup-buildx-action@v2
       - name: Generate PDF
         run: |
           cd $GITHUB_WORKSPACE/${{ inputs.document }}/ && ./generate-pdf -o PR${{ github.event.number }}

--- a/.github/workflows/asciidoctor_pull_request.yaml
+++ b/.github/workflows/asciidoctor_pull_request.yaml
@@ -81,10 +81,14 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
-      - name: Setup Docker on MacOS Runner
-        run: |
-          brew install docker
-          colima start
+      #- name: Setup Docker on MacOS Runner
+      #  run: |
+      #    brew install docker
+      #    colima start
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: Generate PDF
         run: |
           cd $GITHUB_WORKSPACE/${{ inputs.document }}/ && ./generate-pdf -o PR${{ github.event.number }}

--- a/.github/workflows/asciidoctor_pull_request.yaml
+++ b/.github/workflows/asciidoctor_pull_request.yaml
@@ -74,7 +74,7 @@ jobs:
           patterns: ${{ inputs.document }}/**/*.adoc
 
   generate_pdf:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     container:
       image: quay.io/redhat-cop/ubi8-asciidoctor:v2.1
     steps:

--- a/.github/workflows/asciidoctor_pull_request.yaml
+++ b/.github/workflows/asciidoctor_pull_request.yaml
@@ -85,10 +85,6 @@ jobs:
         run: |
           brew install docker
           colima start
-      #- name: Set up QEMU
-      #  uses: docker/setup-qemu-action@v2
-      #- name: Set up Docker Buildx
-      #  uses: docker/setup-buildx-action@v2
       - name: Generate PDF
         run: |
           cd $GITHUB_WORKSPACE/${{ inputs.document }}/ && ./generate-pdf -o PR${{ github.event.number }}

--- a/.github/workflows/asciidoctor_pull_request.yaml
+++ b/.github/workflows/asciidoctor_pull_request.yaml
@@ -75,8 +75,6 @@ jobs:
 
   generate_pdf:
     runs-on: macos-latest
-    container:
-      image: quay.io/redhat-cop/ubi8-asciidoctor:v2.1
     steps:
       - name: Checkout source files
         uses: actions/checkout@v4

--- a/.github/workflows/asciidoctor_pull_request.yaml
+++ b/.github/workflows/asciidoctor_pull_request.yaml
@@ -83,6 +83,10 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+      - name: Setup Docker on MacOS Runner
+        run: |
+          brew install docker
+          colima start
       - name: Generate PDF
         run: |
           cd $GITHUB_WORKSPACE/${{ inputs.document }}/ && ./generate-pdf -o PR${{ github.event.number }}


### PR DESCRIPTION
Currently when building PDFs with asciidoctor in GitHub Actions on Ubuntu and opening them in Acrobat Reader, you get this error:

`Cannot extract the embedded font '...'. Some characters may not display or print correctly.`

You do not get the error when:

* Building the PDF locally on MacOS and opening it in Acrobat Reader
* Opening the PDF built from GitHub Actions in Mac Preview

The fonts are embedded in the PDF. So it seems it is an issue when building on Ubuntu specifically. It could also be related to the fonts.

GitHub had to remove docker from the MacOS images because of licensing issues https://github.com/actions/runner-images/issues/17#issuecomment-614726536, so with MacOS Runner we have to setup Docker.

The change in this PR was successfully tested in https://github.com/stakater-ab/client-proposals/pull/88, after opening the PDF built in that PR, it can successfully be opened on MacOS in Acrobat Reader without getting the error.

Implications to consider from this change:

* It is not entirely clear if the minutes from the Runners will be free or not, since this template is from a public repository, but the repository using it is private
* MacOS runners cost USD 0.08 per minute, while Ubuntu cost one-tenth of that, USD 0.008 per minute
* Setup of Docker takes 3 min
* Building the PDF took more than 6 min
* Compare this with Ubuntu where Docker setup is not needed and PDF build took less than 2 min

There is overall no need to run this job in a container because the PDF build runs through a script which runs the build through a container anyway.