### PR TITLE
Update ot plan and apply with optional secrets

### DIFF
--- a/.github/workflows/ot-plan-apply.yaml
+++ b/.github/workflows/ot-plan-apply.yaml
@@ -26,6 +26,14 @@ on:
       SLACK_WEBHOOK_URL:
         description: "Secret to send success/failure message to slack"
         required: true
+        
+      GRAFANA_ONCALL_ACCESS_TOKEN:
+        description: "Grafana OnCall api token"
+        required: false
+
+      GRAFANA_ONCALL_URL:
+        description: "Grafana OnCall URL"
+        required: false
 
 env:
   GITHUB_OWNER: ${{ secrets.OPENTOFU_GITHUB_OWNER }}


### PR DESCRIPTION
For grafana-cloud-oncall-config repo we need to use GRAFANA_ONCALL_ACCESS_TOKEN and GRAFANA_ONCALL_URL as secrets