### PR TITLE
Install colima for macos runner

### DIFF
--- a/.github/workflows/asciidoctor_push.yaml
+++ b/.github/workflows/asciidoctor_push.yaml
@@ -20,6 +20,7 @@ jobs:
       - name: Setup Docker on MacOS Runner
         run: |
           brew install docker
+          brew install colima
           colima start
       - name: Generate PDF
         run: |


### PR DESCRIPTION
Build currently fails with `colima: command not found`