### PR TITLE
Install colima for PR workflows

### DIFF
--- a/.github/workflows/asciidoctor_pull_request.yaml
+++ b/.github/workflows/asciidoctor_pull_request.yaml
@@ -84,6 +84,7 @@ jobs:
       - name: Setup Docker on MacOS Runner
         run: |
           brew install docker
+          brew install colima
           colima start
       - name: Generate PDF
         run: |


### PR DESCRIPTION
Was missed in https://github.com/stakater-ab/.github/pull/30.

Fails for same reason in pr: `colima: command not found`