### PR TITLE
Link-checker migration to linkspector

### DIFF
--- a/.github/workflows/asciidoctor_pull_request.yaml
+++ b/.github/workflows/asciidoctor_pull_request.yaml
@@ -27,14 +27,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js
-        uses: actions/setup-node@v4
+      - name: Run linkspector
+        uses: umbrelladocs/action-linkspector@v1
         with:
-          node-version: '18.x'
-      - name: Install tool
-        run: npm install -g asciidoc-link-check@1.0.17
-      - name: Check links
-        run: find ${{ inputs.document }}/content -name \*.adoc -exec asciidoc-link-check -p {} \;
+          github_token: ${{ secrets.STAKATER_GITHUB_TOKEN }}
+          reporter: github-pr-review
+          fail_on_error: true
+          filter_mode: nofilter
 
   spell_check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
https://github.com/gaurav-nelson/asciidoc-link-check got archived on 12 May 2024 and suggest to move to `linkspector`

Setting filter mode to show all errors across all files, we might as well run link checker across all content for all PRs