### PR TITLE
Switch runners and remove dependency on macOS

### DIFF
--- a/.github/workflows/asciidoctor_pull_request.yaml
+++ b/.github/workflows/asciidoctor_pull_request.yaml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   link_check:
-    runs-on: ubuntu-latest
+    runs-on: nonprod
     steps:
       - uses: actions/checkout@v4
       - name: Run linkspector
@@ -36,7 +36,7 @@ jobs:
           filter_mode: nofilter
 
   spell_check:
-    runs-on: ubuntu-latest
+    runs-on: nonprod
     steps:
       - uses: actions/checkout@v4
         with:
@@ -60,7 +60,7 @@ jobs:
           ./vale --config='${{ inputs.vale_config }}' ${{ inputs.document }}/content
 
   style_check:
-    runs-on: ubuntu-latest
+    runs-on: nonprod
     steps:
       - uses: actions/checkout@v4
       - name: Style check
@@ -73,16 +73,13 @@ jobs:
           patterns: ${{ inputs.document }}/**/*.adoc
 
   generate_pdf:
-    # ARM64 processors (M1, M2, M3 series) used on macos-14 images are unsupported, they do not support nested virtualization
-    runs-on: macos-13
+    runs-on: nonprod
     steps:
       - name: Checkout source files
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
-      - name: Setup Docker on macOS using Colima, Lima-VM, and Homebrew
-        uses: douglascamata/setup-docker-macos-action@v1-alpha
       - name: Generate PDF
         run: |
           cd $GITHUB_WORKSPACE/${{ inputs.document }}/ && ./generate-pdf -o PR${{ github.event.number }}

--- a/.github/workflows/asciidoctor_push.yaml
+++ b/.github/workflows/asciidoctor_push.yaml
@@ -10,16 +10,13 @@ on:
 
 jobs:
   build:
-    # ARM64 processors (M1, M2, M3 series) used on macos-14 images are unsupported, they do not support nested virtualization
-    runs-on: macos-13
+    runs-on: nonprod
     steps:
       - name: Check out code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
-      - name: Setup Docker on macOS using Colima, Lima-VM, and Homebrew
-        uses: douglascamata/setup-docker-macos-action@v1-alpha
       - name: Generate PDF
         run: |
           cd $GITHUB_WORKSPACE/${{ inputs.document }}/ && ./generate-pdf -o main

--- a/.github/workflows/ot-plan-apply.yaml
+++ b/.github/workflows/ot-plan-apply.yaml
@@ -72,7 +72,7 @@ env:
 
 jobs:
   opentofu-plan-or-apply-on-main:
-    runs-on: ubuntu-latest
+    runs-on: nonprod
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: nonprod
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: nonprod
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/tf-plan-apply.yaml
+++ b/.github/workflows/tf-plan-apply.yaml
@@ -34,7 +34,7 @@ env:
 
 jobs:
   terraform-plan-or-apply-on-main:
-    runs-on: ubuntu-latest
+    runs-on: nonprod
     steps:
     - name: Checkout
       uses: actions/checkout@v4


### PR DESCRIPTION
Workflows should all be using the internal runners for cost reasons.

Switching the font for PDF generation so we can remove the dependency on macOS runners, also for cost reasons.