### PR TITLE
Runner updates

### DIFF
--- a/.github/workflows/asciidoctor_pull_request.yaml
+++ b/.github/workflows/asciidoctor_pull_request.yaml
@@ -74,8 +74,6 @@ jobs:
 
   generate_pdf:
     runs-on: ubuntu-latest
-    container:
-      image: quay.io/redhat-cop/ubi8-asciidoctor:v2.1
     steps:
       - name: Checkout source files
         uses: actions/checkout@v4

--- a/.github/workflows/asciidoctor_pull_request.yaml
+++ b/.github/workflows/asciidoctor_pull_request.yaml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   link_check:
-    runs-on: nonprod
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Run linkspector
@@ -36,7 +36,7 @@ jobs:
           filter_mode: nofilter
 
   spell_check:
-    runs-on: nonprod
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -60,7 +60,7 @@ jobs:
           ./vale --config='${{ inputs.vale_config }}' ${{ inputs.document }}/content
 
   style_check:
-    runs-on: nonprod
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Style check
@@ -73,7 +73,7 @@ jobs:
           patterns: ${{ inputs.document }}/**/*.adoc
 
   generate_pdf:
-    runs-on: nonprod
+    runs-on: ubuntu-latest
     container:
       image: quay.io/redhat-cop/ubi8-asciidoctor:v2.1
     steps:

--- a/.github/workflows/asciidoctor_pull_request.yaml
+++ b/.github/workflows/asciidoctor_pull_request.yaml
@@ -74,6 +74,8 @@ jobs:
 
   generate_pdf:
     runs-on: nonprod
+    container:
+      image: quay.io/redhat-cop/ubi8-asciidoctor:v2.1
     steps:
       - name: Checkout source files
         uses: actions/checkout@v4

--- a/.github/workflows/asciidoctor_push.yaml
+++ b/.github/workflows/asciidoctor_push.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: nonprod
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/ot-plan-apply.yaml
+++ b/.github/workflows/ot-plan-apply.yaml
@@ -72,7 +72,7 @@ env:
 
 jobs:
   opentofu-plan-or-apply-on-main:
-    runs-on: nonprod
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: nonprod
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release:
-    runs-on: nonprod
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/tf-plan-apply.yaml
+++ b/.github/workflows/tf-plan-apply.yaml
@@ -34,7 +34,7 @@ env:
 
 jobs:
   terraform-plan-or-apply-on-main:
-    runs-on: nonprod
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v4


### PR DESCRIPTION
Internally hosted runners give a whole range of weird and convoluted build errors, such as:
* `npm: not found` for actions needing NPM
* `sudo: unable to send audit message: Operation not permitted` for apt-get commands
* `EACCES: permission denied` when checking out source files

The time needed to address these issues is considerably less than the value of being able to run workflows through internal runners, so reverting to using external runners instead.