### PR TITLE
Update artifact path

### DIFF
--- a/.github/workflows/asciidoctor_pull_request.yaml
+++ b/.github/workflows/asciidoctor_pull_request.yaml
@@ -82,11 +82,11 @@ jobs:
           submodules: recursive
       - name: Generate PDF
         run: |
-          cd $GITHUB_WORKSPACE/${{ inputs.document }}/ && ./generate-pdf -o PR-${{ github.event.number }}-${{ github.run_attempt }}
+          cd ${{ github.workspace }}/${{ inputs.document }}/ && ./generate-pdf -o PR-${{ github.event.number }}-${{ inputs.document }}-${{ github.run_attempt }}
       - name: Upload generated PDF
         uses: actions/upload-artifact@v4
         with:
-          name: PR-${{ github.event.number }}-${{ github.run_attempt }}.pdf
-          path: ${{ github.workspace }}/${{ inputs.document }}/PR-${{ github.event.number }}-${{ github.run_attempt }}.pdf
+          name: PR-${{ github.event.number }}-${{ inputs.document }}-${{ github.run_attempt }}.pdf
+          path: ${{ github.workspace }}/${{ inputs.document }}/PR-${{ github.event.number }}-${{ inputs.document }}-${{ github.run_attempt }}.pdf
           retention-days: 5
           if-no-files-found: error

--- a/.github/workflows/asciidoctor_push.yaml
+++ b/.github/workflows/asciidoctor_push.yaml
@@ -19,10 +19,10 @@ jobs:
           submodules: recursive
       - name: Generate PDF
         run: |
-          cd $GITHUB_WORKSPACE/${{ inputs.document }}/ && ./generate-pdf -o main
+          cd ${{ github.workspace }}/${{ inputs.document }}/ && ./generate-pdf -o main-${{ inputs.document }}
       - name: Upload generated PDF
         uses: actions/upload-artifact@v4
         with:
-          name: main.pdf
-          path: ${{ github.workspace }}/${{ inputs.document }}/main.pdf
+          name: main-${{ inputs.document }}.pdf
+          path: ${{ github.workspace }}/${{ inputs.document }}/main-${{ inputs.document }}.pdf
           if-no-files-found: error


### PR DESCRIPTION
The path of the artifact will not be used to store the artifact, it is just the path from where it should be fetched. The name is the only distinguishing data, so it has to be unique across all workflows and runs for each PR.